### PR TITLE
Add frontend tests

### DIFF
--- a/dashboard/frontend/src/components/AdminRoute.test.jsx
+++ b/dashboard/frontend/src/components/AdminRoute.test.jsx
@@ -1,0 +1,64 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter, Routes, Route } from 'react-router-dom';
+import '@testing-library/jest-dom';
+import { vi } from 'vitest';
+import AdminRoute from './AdminRoute';
+
+let authState;
+let adminState;
+vi.mock('../hooks/useAuth.js', () => ({
+  useAuth: () => authState,
+}));
+vi.mock('../hooks/useAdmin.js', () => ({
+  useAdmin: () => adminState,
+}));
+
+const mockHooks = (auth, admin) => {
+  authState = auth;
+  adminState = admin;
+};
+
+describe('AdminRoute', () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('redirects to login when not authenticated', () => {
+    mockHooks({ isAuthenticated: false, loading: false }, { isAdmin: false, loading: false });
+    render(
+      <MemoryRouter initialEntries={['/admin']}>
+        <Routes>
+          <Route path="/login" element={<div>Login Page</div>} />
+          <Route path="/admin" element={<AdminRoute><div>Admin</div></AdminRoute>} />
+        </Routes>
+      </MemoryRouter>
+    );
+    expect(screen.getByText('Login Page')).toBeInTheDocument();
+  });
+
+  it('redirects to home when not an admin', () => {
+    mockHooks({ isAuthenticated: true, loading: false }, { isAdmin: false, loading: false });
+    render(
+      <MemoryRouter initialEntries={['/admin']}>
+        <Routes>
+          <Route path="/" element={<div>Home</div>} />
+          <Route path="/admin" element={<AdminRoute><div>Admin</div></AdminRoute>} />
+        </Routes>
+      </MemoryRouter>
+    );
+    expect(screen.getByText('Home')).toBeInTheDocument();
+  });
+
+  it('renders children when authenticated and admin', () => {
+    mockHooks({ isAuthenticated: true, loading: false }, { isAdmin: true, loading: false });
+    render(
+      <MemoryRouter initialEntries={['/admin']}>
+        <Routes>
+          <Route path="/admin" element={<AdminRoute><div>Admin</div></AdminRoute>} />
+        </Routes>
+      </MemoryRouter>
+    );
+    expect(screen.getByText('Admin')).toBeInTheDocument();
+  });
+});

--- a/dashboard/frontend/src/components/ProtectedRoute.test.jsx
+++ b/dashboard/frontend/src/components/ProtectedRoute.test.jsx
@@ -1,0 +1,58 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter, Routes, Route } from 'react-router';
+import '@testing-library/jest-dom';
+import { vi } from 'vitest';
+import ProtectedRoute from './ProtectedRoute';
+
+let authState;
+vi.mock('../hooks/useAuth.js', () => ({
+  useAuth: () => authState,
+}));
+
+const mockUseAuth = (state) => {
+  authState = state;
+};
+
+describe('ProtectedRoute', () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('shows loading indicator when auth is loading', () => {
+    mockUseAuth({ isAuthenticated: false, loading: true });
+    render(
+      <MemoryRouter initialEntries={['/protected']}>
+        <Routes>
+          <Route path="/protected" element={<ProtectedRoute><div>Protected</div></ProtectedRoute>} />
+        </Routes>
+      </MemoryRouter>
+    );
+    expect(screen.getByText(/Loading.../i)).toBeInTheDocument();
+  });
+
+  it('redirects to login when not authenticated', () => {
+    mockUseAuth({ isAuthenticated: false, loading: false });
+    render(
+      <MemoryRouter initialEntries={['/protected']}>
+        <Routes>
+          <Route path="/login" element={<div>Login Page</div>} />
+          <Route path="/protected" element={<ProtectedRoute><div>Protected</div></ProtectedRoute>} />
+        </Routes>
+      </MemoryRouter>
+    );
+    expect(screen.getByText('Login Page')).toBeInTheDocument();
+  });
+
+  it('renders children when authenticated', () => {
+    mockUseAuth({ isAuthenticated: true, loading: false });
+    render(
+      <MemoryRouter initialEntries={['/protected']}>
+        <Routes>
+          <Route path="/protected" element={<ProtectedRoute><div>Protected</div></ProtectedRoute>} />
+        </Routes>
+      </MemoryRouter>
+    );
+    expect(screen.getByText('Protected')).toBeInTheDocument();
+  });
+});

--- a/dashboard/frontend/src/components/RaidDefenseSettings.test.jsx
+++ b/dashboard/frontend/src/components/RaidDefenseSettings.test.jsx
@@ -1,0 +1,79 @@
+import React from 'react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import axios from 'axios';
+import { vi } from 'vitest';
+import RaidDefenseSettings from './RaidDefenseSettings';
+import { toast } from 'sonner';
+
+vi.mock('axios');
+vi.mock('sonner');
+
+const mockConfig = {
+  enabled: true,
+  threshold: 5,
+  timeframe: 60,
+  alert_channel: '123',
+  auto_action: 'none',
+};
+
+describe('RaidDefenseSettings', () => {
+  beforeEach(() => {
+    axios.get.mockResolvedValue({ data: mockConfig });
+    axios.put.mockResolvedValue({ data: {} });
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('renders loading state initially', async () => {
+    render(<RaidDefenseSettings guildId="123" />);
+    expect(screen.getByText(/Loading.../i)).toBeInTheDocument();
+    await waitFor(() => expect(screen.queryByText(/Loading.../i)).not.toBeInTheDocument());
+  });
+
+  it('renders settings form after loading', async () => {
+    render(<RaidDefenseSettings guildId="123" />);
+    await waitFor(() => {
+      expect(screen.getByLabelText(/Enable Raid Defense/i)).toBeChecked();
+      expect(screen.getByLabelText(/Join Threshold/i)).toHaveValue(mockConfig.threshold);
+      expect(screen.getByLabelText(/Timeframe \(seconds\)/i)).toHaveValue(mockConfig.timeframe);
+      expect(screen.getByLabelText(/Alert Channel ID/i)).toHaveValue(mockConfig.alert_channel);
+    });
+  });
+
+  it('handles input changes', async () => {
+    render(<RaidDefenseSettings guildId="123" />);
+    await waitFor(() => screen.getByLabelText(/Join Threshold/i));
+
+    const thresholdInput = screen.getByLabelText(/Join Threshold/i);
+    fireEvent.change(thresholdInput, { target: { value: '10' } });
+    expect(thresholdInput).toHaveValue(10);
+  });
+
+  it('saves settings and shows success toast', async () => {
+    render(<RaidDefenseSettings guildId="123" />);
+    await waitFor(() => screen.getByText(/Save Raid Defense Settings/i));
+
+    const saveButton = screen.getByText(/Save Raid Defense Settings/i);
+    fireEvent.click(saveButton);
+
+    await waitFor(() => {
+      expect(axios.put).toHaveBeenCalledWith('/api/guilds/123/config/raid-defense', expect.any(Object));
+      expect(toast.success).toHaveBeenCalledWith('Raid defense settings saved successfully');
+    });
+  });
+
+  it('shows an error message if fetching config fails', async () => {
+    const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    axios.get.mockRejectedValue(new Error('Fetch failed'));
+    render(<RaidDefenseSettings guildId="123" />);
+
+    await waitFor(() => {
+      expect(screen.getByText(/Failed to load settings/i)).toBeInTheDocument();
+      expect(toast.error).toHaveBeenCalledWith('Failed to load raid defense settings');
+    });
+    consoleErrorSpy.mockRestore();
+  });
+});

--- a/dashboard/frontend/src/components/RateLimitingSettings.test.jsx
+++ b/dashboard/frontend/src/components/RateLimitingSettings.test.jsx
@@ -1,0 +1,84 @@
+import React from 'react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import axios from 'axios';
+import { vi } from 'vitest';
+import RateLimitingSettings from './RateLimitingSettings';
+import { toast } from 'sonner';
+
+vi.mock('axios');
+vi.mock('sonner');
+
+const mockConfig = {
+  enabled: true,
+  high_rate_threshold: 10,
+  low_rate_threshold: 3,
+  high_rate_slowmode: 5,
+  low_rate_slowmode: 2,
+  check_interval: 30,
+  analysis_window: 60,
+  notification_channel: '123',
+  notifications_enabled: true,
+};
+
+describe('RateLimitingSettings', () => {
+  beforeEach(() => {
+    axios.get.mockResolvedValue({ data: mockConfig });
+    axios.put.mockResolvedValue({ data: {} });
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('renders loading state initially', async () => {
+    render(<RateLimitingSettings guildId="123" />);
+    expect(screen.getByText(/Loading.../i)).toBeInTheDocument();
+    await waitFor(() => expect(screen.queryByText(/Loading.../i)).not.toBeInTheDocument());
+  });
+
+  it('renders settings form after loading', async () => {
+    render(<RateLimitingSettings guildId="123" />);
+    await waitFor(() => {
+      expect(screen.getByLabelText(/Enable Automatic Rate Limiting/i)).toBeChecked();
+      expect(screen.getByLabelText(/High Rate Threshold/i)).toHaveValue(mockConfig.high_rate_threshold);
+      expect(screen.getByLabelText(/Low Rate Threshold/i)).toHaveValue(mockConfig.low_rate_threshold);
+      expect(screen.getByLabelText(/High Rate Slowmode \(s\)/i)).toHaveValue(mockConfig.high_rate_slowmode);
+      expect(screen.getByLabelText(/Low Rate Slowmode \(s\)/i)).toHaveValue(mockConfig.low_rate_slowmode);
+    });
+  });
+
+  it('handles input changes', async () => {
+    render(<RateLimitingSettings guildId="123" />);
+    await waitFor(() => screen.getByLabelText(/High Rate Threshold/i));
+
+    const thresholdInput = screen.getByLabelText(/High Rate Threshold/i);
+    fireEvent.change(thresholdInput, { target: { value: '20' } });
+    expect(thresholdInput).toHaveValue(20);
+  });
+
+  it('saves settings and shows success toast', async () => {
+    render(<RateLimitingSettings guildId="123" />);
+    await waitFor(() => screen.getByText(/Save Rate Limiting Settings/i));
+
+    const saveButton = screen.getByText(/Save Rate Limiting Settings/i);
+    fireEvent.click(saveButton);
+
+    await waitFor(() => {
+      expect(axios.put).toHaveBeenCalledWith('/api/guilds/123/config/message-rate', expect.any(Object));
+      expect(toast.success).toHaveBeenCalledWith('Rate limiting settings saved successfully');
+    });
+  });
+
+  it('shows an error message if fetching config fails', async () => {
+    const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    axios.get.mockRejectedValue(new Error('Fetch failed'));
+    render(<RateLimitingSettings guildId="123" />);
+
+    await waitFor(() => {
+      expect(screen.getByText(/Failed to load settings/i)).toBeInTheDocument();
+      expect(toast.error).toHaveBeenCalledWith('Failed to load rate limiting settings');
+    });
+    consoleErrorSpy.mockRestore();
+  });
+});

--- a/dashboard/frontend/src/components/SecuritySettings.test.jsx
+++ b/dashboard/frontend/src/components/SecuritySettings.test.jsx
@@ -1,0 +1,87 @@
+import React from 'react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import axios from 'axios';
+import { vi } from 'vitest';
+import SecuritySettings from './SecuritySettings';
+import { toast } from 'sonner';
+
+vi.mock('axios');
+vi.mock('sonner');
+
+const mockConfig = {
+  enabled: true,
+  action: 'warn',
+  timeout_duration: 300,
+  keywords: ['spam'],
+  log_channel: '123',
+};
+
+describe('SecuritySettings', () => {
+  beforeEach(() => {
+    axios.get.mockResolvedValue({ data: mockConfig });
+    axios.put.mockResolvedValue({ data: {} });
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('renders loading state initially', async () => {
+    render(<SecuritySettings guildId="123" />);
+    expect(screen.getByText(/Loading.../i)).toBeInTheDocument();
+    await waitFor(() => expect(screen.queryByText(/Loading.../i)).not.toBeInTheDocument());
+  });
+
+  it('renders settings form after loading', async () => {
+    render(<SecuritySettings guildId="123" />);
+    await waitFor(() => {
+      expect(screen.getByLabelText(/Enable Bot Detection/i)).toBeChecked();
+      expect(screen.getByLabelText(/Timeout Duration \(seconds\)/i)).toHaveValue(mockConfig.timeout_duration);
+      expect(screen.getByLabelText(/Log Channel ID/i)).toHaveValue(mockConfig.log_channel);
+    });
+  });
+
+  it('handles keyword add and remove', async () => {
+    render(<SecuritySettings guildId="123" />);
+    const addButton = await screen.findByRole('button', { name: /Add Keyword/i });
+
+    fireEvent.click(addButton);
+    const inputs = screen.getAllByPlaceholderText(/Enter keyword/i);
+    expect(inputs).toHaveLength(2);
+
+    fireEvent.change(inputs[1], { target: { value: 'bot' } });
+    expect(inputs[1]).toHaveValue('bot');
+
+    const removeButtons = screen.getAllByText(/Remove/i);
+    fireEvent.click(removeButtons[1]);
+    await waitFor(() => {
+      expect(screen.getAllByPlaceholderText(/Enter keyword/i)).toHaveLength(1);
+    });
+  });
+
+  it('saves settings and shows success toast', async () => {
+    render(<SecuritySettings guildId="123" />);
+    await waitFor(() => screen.getByText(/Save Security Settings/i));
+
+    const saveButton = screen.getByText(/Save Security Settings/i);
+    fireEvent.click(saveButton);
+
+    await waitFor(() => {
+      expect(axios.put).toHaveBeenCalledWith('/api/guilds/123/config/bot-detection', expect.any(Object));
+      expect(toast.success).toHaveBeenCalledWith('Security settings saved successfully');
+    });
+  });
+
+  it('shows an error message if fetching config fails', async () => {
+    const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    axios.get.mockRejectedValue(new Error('Fetch failed'));
+    render(<SecuritySettings guildId="123" />);
+
+    await waitFor(() => {
+      expect(screen.getByText(/Failed to load settings/i)).toBeInTheDocument();
+      expect(toast.error).toHaveBeenCalledWith('Failed to load security settings');
+    });
+    consoleErrorSpy.mockRestore();
+  });
+});


### PR DESCRIPTION
## Summary
- add tests for AdminRoute and ProtectedRoute components
- add tests for raid defense, rate limiting and security settings components
- ensure Python and node tests run without errors

## Testing
- `pytest`
- `npx pyright` *(fails: npm error canceled)*
- `npm run build` within `website/`
- `npm run test` within `dashboard/frontend`
- `npm run lint` within `dashboard/frontend`
- `npm run build` within `dashboard/frontend`


------
https://chatgpt.com/codex/tasks/task_e_6879c88d033c83238451865ff7b87384